### PR TITLE
Add footer, RSS feed, prev/next nav, and visual polish (Tier 1)

### DIFF
--- a/build.php
+++ b/build.php
@@ -118,8 +118,12 @@ foreach ($folders as $folder) {
         continue;
     }
 
+    $adjacent = $postService->findAdjacentPosts($slug);
+
     $html = $twig->render('index.twig', [
         'post'     => $post,
+        'newer'    => $adjacent['newer'],
+        'older'    => $adjacent['older'],
         'settings' => $settings,
     ]);
 
@@ -159,5 +163,40 @@ foreach ($posts as $post) {
 $sitemapLines[] = '</urlset>';
 file_put_contents($dist . '/sitemap.xml', implode("\n", $sitemapLines) . "\n");
 echo "  ✓ /sitemap.xml (generated)\n";
+
+// ── generate rss.xml ───────────────────────────────────────────────
+
+$rssLines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom">',
+    '<channel>',
+    '  <title>jack marchant</title>',
+    '  <link>' . $siteUrl . '/</link>',
+    '  <description>writing about software</description>',
+    '  <language>en</language>',
+    '  <atom:link href="' . $siteUrl . '/rss.xml" rel="self" type="application/rss+xml" />',
+];
+
+foreach ($posts as $timestamp => $listing) {
+    $slug = ltrim($listing['url'], '/');
+    $full = $postService->findPostByPath($slug);
+    if (empty($full)) {
+        continue;
+    }
+    $itemUrl = $siteUrl . $listing['url'];
+    $rssLines[] = '<item>';
+    $rssLines[] = '  <title>' . htmlspecialchars($listing['title'], ENT_XML1, 'UTF-8') . '</title>';
+    $rssLines[] = '  <link>' . htmlspecialchars($itemUrl, ENT_XML1, 'UTF-8') . '</link>';
+    $rssLines[] = '  <guid isPermaLink="true">' . htmlspecialchars($itemUrl, ENT_XML1, 'UTF-8') . '</guid>';
+    $rssLines[] = '  <pubDate>' . date(DATE_RSS, $timestamp) . '</pubDate>';
+    $rssLines[] = '  <description>' . htmlspecialchars(trim(strip_tags($full['blurb'])), ENT_XML1, 'UTF-8') . '</description>';
+    $rssLines[] = '  <content:encoded><![CDATA[' . $full['content'] . ']]></content:encoded>';
+    $rssLines[] = '</item>';
+}
+
+$rssLines[] = '</channel>';
+$rssLines[] = '</rss>';
+file_put_contents($dist . '/rss.xml', implode("\n", $rssLines) . "\n");
+echo "  ✓ /rss.xml (generated)\n";
 
 echo "\nBuild complete → {$dist}\n";

--- a/public/index.js
+++ b/public/index.js
@@ -220,10 +220,79 @@
         });
     }
 
+    function setupCurrentYear() {
+        var el = document.querySelector('[data-current-year]');
+        if (el) {
+            el.textContent = String(new Date().getFullYear());
+        }
+    }
+
+    function setupCodeBlocks() {
+        var pres = document.querySelectorAll('.post pre[class*="language-"]');
+        pres.forEach(function (pre) {
+            if (pre.parentElement && pre.parentElement.classList.contains('code-block')) {
+                return;
+            }
+
+            var match = pre.className.match(/language-([\w-]+)/);
+            var lang = match ? match[1] : 'code';
+
+            var wrapper = document.createElement('div');
+            wrapper.className = 'code-block';
+
+            var header = document.createElement('div');
+            header.className = 'code-block__header';
+
+            var langEl = document.createElement('span');
+            langEl.className = 'code-block__lang';
+            langEl.textContent = lang;
+
+            var btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'code-block__copy';
+            btn.setAttribute('aria-label', 'copy code');
+            btn.textContent = 'copy';
+
+            header.appendChild(langEl);
+            header.appendChild(btn);
+
+            pre.parentNode.insertBefore(wrapper, pre);
+            wrapper.appendChild(header);
+            wrapper.appendChild(pre);
+
+            btn.addEventListener('click', function () {
+                var text = pre.textContent || '';
+                var done = function () {
+                    btn.textContent = 'copied';
+                    setTimeout(function () { btn.textContent = 'copy'; }, 1500);
+                };
+
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(text).then(done, function () {
+                        btn.textContent = 'failed';
+                        setTimeout(function () { btn.textContent = 'copy'; }, 1500);
+                    });
+                } else {
+                    var ta = document.createElement('textarea');
+                    ta.value = text;
+                    ta.setAttribute('readonly', '');
+                    ta.style.position = 'absolute';
+                    ta.style.left = '-9999px';
+                    document.body.appendChild(ta);
+                    ta.select();
+                    try { document.execCommand('copy'); done(); } catch (e) {}
+                    document.body.removeChild(ta);
+                }
+            });
+        });
+    }
+
     document.addEventListener('DOMContentLoaded', function () {
         setupExpanding();
         setupThemeToggle();
         setupReadingProgress();
+        setupCurrentYear();
+        setupCodeBlocks();
         var closeModal = setupSubscribeModal();
 
         if (closeModal) {

--- a/public/style.css
+++ b/public/style.css
@@ -15,6 +15,8 @@ https://prismjs.com/download.html#themes=prism-tomorrow&languages=markup+clike+j
     --text-muted-color: #b4c1d8;
     --accent-blue-color: #7ab8ff;
     --accent-green-color: #63d297;
+    --code-bg-color: #2d2d2d;
+    --code-text-color: #ccc;
     --tag-elixir-color: #bf9bff;
     --tag-ai-color: #7ab8ff;
     --tag-database-color: #63d297;
@@ -34,6 +36,8 @@ https://prismjs.com/download.html#themes=prism-tomorrow&languages=markup+clike+j
     --text-muted-color: #4b5e78;
     --accent-blue-color: #1d6fa8;
     --accent-green-color: #1a7a46;
+    --code-bg-color: #f1f3f7;
+    --code-text-color: #1f2630;
     --tag-elixir-color: #7b4db5;
     --tag-ai-color: #1d6fa8;
     --tag-database-color: #1a7a46;
@@ -46,7 +50,7 @@ https://prismjs.com/download.html#themes=prism-tomorrow&languages=markup+clike+j
 
  code[class*="language-"],
  pre[class*="language-"] {
-     color: #ccc;
+     color: var(--code-text-color);
      background: none;
      font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
      font-size: 1em;
@@ -79,7 +83,7 @@ https://prismjs.com/download.html#themes=prism-tomorrow&languages=markup+clike+j
  
  :not(pre) > code[class*="language-"],
  pre[class*="language-"] {
-     background: #2d2d2d;
+     background: var(--code-bg-color);
      border-radius: 4px;
  }
  
@@ -163,8 +167,38 @@ https://prismjs.com/download.html#themes=prism-tomorrow&languages=markup+clike+j
  .token.inserted {
      color: green;
  }
- 
- 
+
+[data-theme="light"] .token.comment,
+[data-theme="light"] .token.block-comment,
+[data-theme="light"] .token.prolog,
+[data-theme="light"] .token.doctype,
+[data-theme="light"] .token.cdata        { color: #6b7280; }
+[data-theme="light"] .token.punctuation  { color: #1f2630; }
+[data-theme="light"] .token.tag,
+[data-theme="light"] .token.attr-name,
+[data-theme="light"] .token.namespace,
+[data-theme="light"] .token.deleted      { color: #b03a3a; }
+[data-theme="light"] .token.function-name{ color: #1d4ed8; }
+[data-theme="light"] .token.boolean,
+[data-theme="light"] .token.number,
+[data-theme="light"] .token.function     { color: #b45309; }
+[data-theme="light"] .token.property,
+[data-theme="light"] .token.class-name,
+[data-theme="light"] .token.constant,
+[data-theme="light"] .token.symbol       { color: #92400e; }
+[data-theme="light"] .token.selector,
+[data-theme="light"] .token.important,
+[data-theme="light"] .token.atrule,
+[data-theme="light"] .token.keyword,
+[data-theme="light"] .token.builtin      { color: #6d28d9; }
+[data-theme="light"] .token.string,
+[data-theme="light"] .token.char,
+[data-theme="light"] .token.attr-value,
+[data-theme="light"] .token.regex,
+[data-theme="light"] .token.variable     { color: #15803d; }
+[data-theme="light"] .token.operator,
+[data-theme="light"] .token.entity,
+[data-theme="light"] .token.url          { color: #0e7490; }
 
 body {
     margin: 0;
@@ -178,7 +212,7 @@ a {
 }
 
 .container {
-    max-width: 640px;
+    max-width: 680px;
     margin: 0 auto;
     padding: 0 16px;
 }
@@ -546,8 +580,22 @@ main {
 
 .post__title {
     margin: 0 0 4px;
-    font-size: 28px;
+    font-size: 32px;
+    letter-spacing: -0.01em;
+    text-wrap: balance;
     text-transform: lowercase;
+}
+
+.post h2 {
+    font-size: 1.6rem;
+    margin: 2.4rem 0 0.8rem;
+    line-height: 1.25;
+}
+
+.post h3 {
+    font-size: 1.25rem;
+    margin: 1.8rem 0 0.6rem;
+    line-height: 1.3;
 }
 
 .post__date {
@@ -586,8 +634,9 @@ main {
 
 .post p, .post li {
     color: var(--text-primary-color);
-    font-size: 15px;
+    font-size: 16px;
     line-height: 1.75;
+    text-wrap: pretty;
 }
 
 .post ul {
@@ -641,6 +690,176 @@ main {
 
 .tweet-card__link:hover {
     color: var(--accent-blue-color);
+}
+
+.post-nav {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    gap: 12px;
+    align-items: center;
+    margin: 40px 0 8px;
+    padding-top: 24px;
+    border-top: 1px solid var(--border-color);
+    font-family: 'Space Mono', monospace;
+}
+
+.post-nav__link {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 12px 14px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    text-decoration: none;
+    color: var(--text-primary-color);
+    transition: border-color 120ms ease, color 120ms ease;
+    overflow-wrap: anywhere;
+}
+
+.post-nav__link--next {
+    text-align: right;
+}
+
+.post-nav__link:hover {
+    border-color: var(--border-hover-color);
+    color: var(--accent-blue-color);
+}
+
+.post-nav__label {
+    font-size: 11px;
+    color: var(--text-muted-color);
+    text-transform: lowercase;
+}
+
+.post-nav__title {
+    font-size: 13px;
+}
+
+.post-nav__home {
+    align-self: center;
+    font-family: 'Space Mono', monospace;
+    font-size: 12px;
+    color: var(--text-muted-color);
+    text-decoration: none;
+    padding: 4px 8px;
+    transition: color 120ms ease;
+}
+
+.post-nav__home:hover {
+    color: var(--accent-blue-color);
+}
+
+.post-nav__placeholder {
+    display: block;
+}
+
+.code-block {
+    margin: 18px 0;
+    border: 1px solid var(--border-color);
+    border-left: 3px solid var(--accent-blue-color);
+    border-radius: 6px;
+    overflow: hidden;
+    background: var(--code-bg-color);
+}
+
+.code-block__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 6px 10px;
+    background: var(--surface-color);
+    border-bottom: 1px solid var(--border-color);
+    font-family: 'Space Mono', monospace;
+    font-size: 11px;
+}
+
+.code-block__lang {
+    color: var(--text-muted-color);
+    text-transform: lowercase;
+    letter-spacing: 0.04em;
+}
+
+.code-block__copy {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--text-muted-color);
+    padding: 2px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 11px;
+    transition: border-color 120ms ease, color 120ms ease;
+}
+
+.code-block__copy:hover {
+    border-color: var(--border-hover-color);
+    color: var(--text-primary-color);
+}
+
+.code-block pre[class*="language-"] {
+    margin: 0;
+    border-radius: 0;
+    background: var(--code-bg-color);
+}
+
+@media (max-width: 600px) {
+    .site-header {
+        position: static;
+        padding: 10px 0 8px;
+    }
+
+    .site-tagline {
+        display: none;
+    }
+
+    .reading-progress {
+        top: auto;
+        bottom: 0;
+    }
+
+    .post p, .post li {
+        font-size: 15px;
+    }
+
+    .post__title {
+        font-size: 28px;
+    }
+
+    .tag-filter-btn {
+        padding: 7px 14px;
+        font-size: 12px;
+    }
+
+    .subscribe-modal__dialog {
+        max-height: 90dvh;
+        overflow-y: auto;
+    }
+
+    .post-nav {
+        grid-template-columns: 1fr;
+        gap: 8px;
+    }
+
+    .post-nav__link--next {
+        text-align: left;
+    }
+
+    .post-nav__home {
+        order: 2;
+        text-align: center;
+    }
+
+    .post-nav__link--prev {
+        order: 1;
+    }
+
+    .post-nav__link--next {
+        order: 3;
+    }
+
+    .post-nav__placeholder {
+        display: none;
+    }
 }
 
 @media (max-width: 480px) {
@@ -762,4 +981,47 @@ main {
 
 .post-directory {
     margin-top: 20px;
+}
+
+.site-footer {
+    padding: 32px 0 48px;
+    margin-top: 48px;
+    border-top: 1px solid var(--border-color);
+}
+
+.site-footer__prompt {
+    margin: 0 0 8px;
+    color: var(--accent-green-color);
+    font-family: 'Space Mono', monospace;
+    font-size: 12px;
+}
+
+.site-footer__links {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    font-family: 'Space Mono', monospace;
+    font-size: 13px;
+}
+
+.site-footer__links a {
+    color: var(--text-muted-color);
+    text-decoration: none;
+    transition: color 120ms ease;
+}
+
+.site-footer__links a:hover {
+    color: var(--accent-blue-color);
+}
+
+.site-footer__links span {
+    color: var(--border-hover-color);
+}
+
+.site-footer__meta {
+    margin: 16px 0 0;
+    color: var(--text-muted-color);
+    font-family: 'Space Mono', monospace;
+    font-size: 11px;
 }

--- a/src/BlogPostController.php
+++ b/src/BlogPostController.php
@@ -34,11 +34,13 @@ class BlogPostController
         $this->logger->info('blog post handler dispatched');
 
         $post = ['title' => 'Page not found'];
+        $adjacent = ['newer' => null, 'older' => null];
 
         if (isset($args['post'])) {
             $foundPost = $this->postService->findPostByPath($args['post']);
             if (!empty($foundPost)) {
                 $post = $foundPost;
+                $adjacent = $this->postService->findAdjacentPosts($args['post']);
             }
         }
 
@@ -52,6 +54,8 @@ class BlogPostController
 
         $body = $this->renderer->render('index.twig', [
             'post' => $post,
+            'newer' => $adjacent['newer'],
+            'older' => $adjacent['older'],
             'settings' => $this->settings,
         ]);
         $response->getBody()->write($body);

--- a/src/Services/PostService.php
+++ b/src/Services/PostService.php
@@ -136,6 +136,35 @@ class PostService
     }
 
     /**
+     * Find the chronologically adjacent posts for a given slug.
+     * Listings are sorted newest-first, so the index BEFORE the current
+     * post is the "newer" neighbour, and the index AFTER is the "older".
+     *
+     * @param string $slug
+     * @return array{newer: ?array, older: ?array}
+     */
+    public function findAdjacentPosts(string $slug): array
+    {
+        $posts = array_values($this->getAllPostListings());
+        $idx = null;
+        foreach ($posts as $i => $post) {
+            if ($post['url'] === '/' . $slug) {
+                $idx = $i;
+                break;
+            }
+        }
+
+        if ($idx === null) {
+            return ['newer' => null, 'older' => null];
+        }
+
+        return [
+            'newer' => $idx > 0 ? $posts[$idx - 1] : null,
+            'older' => $idx < count($posts) - 1 ? $posts[$idx + 1] : null,
+        ];
+    }
+
+    /**
      * Get all unique tags from a posts array, sorted alphabetically.
      *
      * @param array $posts

--- a/src/Services/PostService.php
+++ b/src/Services/PostService.php
@@ -12,6 +12,9 @@ class PostService
     /** @var MarkdownParserInterface */
     private $parser;
 
+    /** @var array|null Memoized listings — filesystem scan + metadata parse is expensive */
+    private $listingsCache;
+
     public function __construct(MarkdownParserInterface $parser)
     {
         $this->parser = $parser;
@@ -55,9 +58,13 @@ class PostService
      */
     public function getAllPostListings(): array
     {
+        if ($this->listingsCache !== null) {
+            return $this->listingsCache;
+        }
+
         $folders = array_filter(glob(__DIR__ . self::CONTENT_PATH . '/*'), 'is_dir');
         $posts = [];
-        
+
         foreach ($folders as $folder) {
             $paths = explode('/', $folder);
             $path = end($paths);
@@ -74,6 +81,7 @@ class PostService
 
         krsort($posts);
 
+        $this->listingsCache = $posts;
         return $posts;
     }
 

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -28,6 +28,7 @@
         <meta name="twitter:description" content="I'm a Software Engineer from Sydney. I like writing code and talking about it." />
         {% endif %}
         <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+        <link rel="alternate" type="application/rss+xml" title="jack marchant" href="/rss.xml" />
         <script>(function(){try{var t=localStorage.getItem('theme')||'dark';document.documentElement.setAttribute('data-theme',t);}catch(e){}}());</script>
     </head>
     <body>
@@ -114,8 +115,47 @@
                     {% endif %}
                     {{ post.content|raw }}
                 </article>
+                {% if newer or older %}
+                <nav class="post-nav" aria-label="post navigation">
+                    {% if older %}
+                        <a class="post-nav__link post-nav__link--prev" href="{{ older.url }}">
+                            <span class="post-nav__label">← older</span>
+                            <span class="post-nav__title">{{ older.title|lower }}</span>
+                        </a>
+                    {% else %}
+                        <span class="post-nav__placeholder" aria-hidden="true"></span>
+                    {% endif %}
+                    <a class="post-nav__home" href="/">all posts</a>
+                    {% if newer %}
+                        <a class="post-nav__link post-nav__link--next" href="{{ newer.url }}">
+                            <span class="post-nav__label">newer →</span>
+                            <span class="post-nav__title">{{ newer.title|lower }}</span>
+                        </a>
+                    {% else %}
+                        <span class="post-nav__placeholder" aria-hidden="true"></span>
+                    {% endif %}
+                </nav>
+                {% endif %}
             {% endif %}
         </main>
+
+        <footer class="site-footer">
+            <div class="container">
+                <p class="site-footer__prompt">jackmarchant@blog:~$ exit</p>
+                <nav class="site-footer__links" aria-label="external links">
+                    <a href="/rss.xml">rss</a>
+                    <span aria-hidden="true">·</span>
+                    <a href="https://github.com/jackmarchant" target="_blank" rel="noopener noreferrer">github</a>
+                    <span aria-hidden="true">·</span>
+                    <a href="https://x.com/jackmarchant" target="_blank" rel="noopener noreferrer">x</a>
+                    <span aria-hidden="true">·</span>
+                    <a href="https://www.linkedin.com/in/jackmarchant" target="_blank" rel="noopener noreferrer">linkedin</a>
+                    <span aria-hidden="true">·</span>
+                    <a href="mailto:hello@jackmarchant.com">email</a>
+                </nav>
+                <p class="site-footer__meta">© <span data-current-year>2026</span> jack marchant</p>
+            </div>
+        </footer>
 
         <script src="/prism.js"></script>
         <script src="/index.js"></script>

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -147,11 +147,11 @@
                     <span aria-hidden="true">·</span>
                     <a href="https://github.com/jackmarchant" target="_blank" rel="noopener noreferrer">github</a>
                     <span aria-hidden="true">·</span>
-                    <a href="https://x.com/jackmarchant" target="_blank" rel="noopener noreferrer">x</a>
+                    <a href="https://x.com/jackmarchant10" target="_blank" rel="noopener noreferrer" aria-label="x profile">x</a>
                     <span aria-hidden="true">·</span>
-                    <a href="https://www.linkedin.com/in/jackmarchant" target="_blank" rel="noopener noreferrer">linkedin</a>
+                    <a href="https://www.linkedin.com/in/jack-marchant" target="_blank" rel="noopener noreferrer">linkedin</a>
                     <span aria-hidden="true">·</span>
-                    <a href="mailto:hello@jackmarchant.com">email</a>
+                    <a href="mailto:jack@jackmarchant.com">email</a>
                 </nav>
                 <p class="site-footer__meta">© <span data-current-year>2026</span> jack marchant</p>
             </div>


### PR DESCRIPTION
- Site footer with RSS, GitHub, X, LinkedIn, and email links
- /rss.xml generated with full post content (RFC-822 dates) plus
  auto-discovery <link> in <head>
- Chronological prev/next post navigation, with a "all posts" link,
  via PostService::findAdjacentPosts
- Post typography pass: wider container (680px), larger H2/H3,
  16px body with text-wrap: pretty/balance
- Code blocks gain a language label, copy button, and theme-aware
  syntax colors (Prism background and tokens now respect light theme)
- Mobile pass at 600px: non-sticky header, hidden tagline, larger
  tag-filter tap targets, reading-progress bar moved to bottom,
  stacked post-nav, modal max-height: 90dvh