### PR TITLE
Fix reading progress bar to top on mobile

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -812,12 +812,7 @@ main {
         display: none;
     }
 
-    .reading-progress {
-        top: auto;
-        bottom: 0;
-    }
-
-    .post p, .post li {
+.post p, .post li {
         font-size: 15px;
     }
 


### PR DESCRIPTION
The mobile media query was overriding top: 0 with bottom: 0, placing
the bar at the bottom of the screen. Removed the override so it stays
fixed to the top on all screen sizes.

https://claude.ai/code/session_012KMprKixV4K9hVvi4Sbi5C