### PR TITLE
Add GitHub Action to build static site and publish to deploy branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: build-and-publish-dist
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - run: composer install --no-dev --optimize-autoloader
+
+      - run: php build.php
+
+      - name: Publish dist/ to deploy branch
+        run: |
+          cd dist
+          git init -b deploy
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "build: ${GITHUB_SHA::7}"
+          git push --force "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" deploy


### PR DESCRIPTION
On every push to main, runs composer install && php build.php and
force-pushes the resulting dist/ to a dedicated deploy branch. The EC2
host clones that branch directly, so no PHP runtime is needed on the
server.

https://claude.ai/code/session_01NsJEAvUs76gJ2gLimbK8YV