### PR TITLE
Restore sticky header on mobile

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -804,7 +804,6 @@ main {
 
 @media (max-width: 600px) {
     .site-header {
-        position: static;
         padding: 10px 0 8px;
     }
 


### PR DESCRIPTION
Remove the mobile override that set position: static on .site-header so
the header stays pinned to the top like on desktop.