### PR TITLE
Add cache-busting via content-hashed asset URLs

### DIFF
--- a/build.php
+++ b/build.php
@@ -11,6 +11,8 @@
 error_reporting(E_ALL ^ E_DEPRECATED);
 require __DIR__ . '/vendor/autoload.php';
 
+use App\Assets;
+use App\AssetsExtension;
 use App\Markdown;
 use App\Services\PostService;
 
@@ -53,6 +55,8 @@ $postService = new PostService($markdown);
 // the blog list (when 'posts' is set) or a single post (when 'post' is set).
 $loader   = new Twig\Loader\FilesystemLoader(__DIR__ . '/templates');
 $twig     = new Twig\Environment($loader);
+$assets   = new Assets(__DIR__ . '/public');
+$twig->addExtension(new AssetsExtension($assets));
 $settings = [
     'environment' => 'production',
 ];
@@ -88,6 +92,15 @@ foreach (scandir($publicDir) as $item) {
         copyDir($srcPath, $dstPath);
     } else {
         copy($srcPath, $dstPath);
+    }
+}
+
+// Write hashed copies of bundled assets so the static site can serve them
+// at the same URLs the template references via {{ asset(...) }}.
+foreach (['/style.css', '/prism.css', '/index.js', '/prism.js'] as $assetPath) {
+    $hashedPath = $assets->path($assetPath);
+    if ($hashedPath !== $assetPath) {
+        copy($publicDir . $assetPath, $dist . $hashedPath);
     }
 }
 

--- a/deploy/nginx.conf.example
+++ b/deploy/nginx.conf.example
@@ -1,0 +1,15 @@
+# Cache-busting + long-lived caching for hashed assets.
+#
+# Templates reference assets via /name.<hash8>.ext (e.g. /style.7bc36a27.css).
+# This block matches that pattern, serves the canonical file from disk, and
+# tells the browser to cache it forever — safe because the URL changes
+# whenever the file content changes.
+#
+# Drop this inside the `server { }` block that serves jackmarchant.com,
+# above any catch-all `location /` rule.
+
+location ~ "^/(.+)\.[a-f0-9]{8}\.(css|js)$" {
+    try_files /$1.$2 =404;
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+}

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,5 +6,14 @@ RewriteEngine On
 #
 # RewriteBase /
 
+# Cache-busting: serve hashed asset URLs (e.g. /style.a1b2c3d4.css) from the canonical file
+RewriteRule ^(.+)\.[a-f0-9]{8}\.(css|js)$ /$1.$2 [L]
+
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule ^ index.php [QSA,L]
+
+<IfModule mod_headers.c>
+    <FilesMatch "\.[a-f0-9]{8}\.(css|js)$">
+        Header set Cache-Control "public, max-age=31536000, immutable"
+    </FilesMatch>
+</IfModule>

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,14 +6,5 @@ RewriteEngine On
 #
 # RewriteBase /
 
-# Cache-busting: serve hashed asset URLs (e.g. /style.a1b2c3d4.css) from the canonical file
-RewriteRule ^(.+)\.[a-f0-9]{8}\.(css|js)$ /$1.$2 [L]
-
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule ^ index.php [QSA,L]
-
-<IfModule mod_headers.c>
-    <FilesMatch "\.[a-f0-9]{8}\.(css|js)$">
-        Header set Cache-Control "public, max-age=31536000, immutable"
-    </FilesMatch>
-</IfModule>

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App;
+
+class Assets
+{
+    private string $publicDir;
+    private array $cache = [];
+
+    public function __construct(string $publicDir)
+    {
+        $this->publicDir = rtrim($publicDir, '/');
+    }
+
+    public function path(string $path): string
+    {
+        if (isset($this->cache[$path])) {
+            return $this->cache[$path];
+        }
+
+        $file = $this->publicDir . $path;
+        if (!is_file($file)) {
+            return $this->cache[$path] = $path;
+        }
+
+        $hash = substr(md5_file($file), 0, 8);
+        $info = pathinfo($path);
+        $dir = $info['dirname'] === '/' ? '' : $info['dirname'];
+        $ext = isset($info['extension']) ? '.' . $info['extension'] : '';
+
+        return $this->cache[$path] = $dir . '/' . $info['filename'] . '.' . $hash . $ext;
+    }
+}

--- a/src/AssetsExtension.php
+++ b/src/AssetsExtension.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class AssetsExtension extends AbstractExtension
+{
+    public function __construct(private Assets $assets) {}
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('asset', [$this, 'path']),
+        ];
+    }
+
+    public function path(string $p): string
+    {
+        return $this->assets->path($p);
+    }
+}

--- a/src/dependencies.php
+++ b/src/dependencies.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Assets;
+use App\AssetsExtension;
 use App\Services\PostService;
 use App\Markdown;
 use \Psr\Container\ContainerInterface;
@@ -10,12 +12,18 @@ $container->set('settings', function (ContainerInterface $c) {
     return require __DIR__ . '/settings.php';
 });
 
+$container->set('assets', function (ContainerInterface $c) {
+    return new Assets(__DIR__ . '/../public');
+});
+
 // view renderer
 $container->set('renderer', function (ContainerInterface $c) {
     $loader = new Twig\Loader\FilesystemLoader(__DIR__ . '/../templates');
-    return new Twig\Environment($loader, [
+    $env = new Twig\Environment($loader, [
         __DIR__ . '/../var/cache'
     ]);
+    $env->addExtension(new AssetsExtension($c->get('assets')));
+    return $env;
 });
 
 $container->set('markdown', function(ContainerInterface $c) {

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -6,8 +6,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
         <title>{% if post %}{{ post.title|lower }} | {% endif %}jack marchant</title>
         <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
-        <link href="/prism.css" rel="stylesheet" type="text/css" />
-        <link href="/style.css" rel="stylesheet" type="text/css" />
+        <link href="{{ asset('/prism.css') }}" rel="stylesheet" type="text/css" />
+        <link href="{{ asset('/style.css') }}" rel="stylesheet" type="text/css" />
         {% if post %}
         <meta name="description" content="{{ post.blurb|e }}" />
         <meta property="og:type" content="article" />
@@ -190,8 +190,8 @@
             </div>
         </footer>
 
-        <script src="/prism.js"></script>
-        <script src="/index.js"></script>
+        <script src="{{ asset('/prism.js') }}"></script>
+        <script src="{{ asset('/index.js') }}"></script>
 
         {% if settings.environment == 'production' %}
             <!-- Google tag (gtag.js) -->


### PR DESCRIPTION
The template now references /style.<hash>.css etc. via a Twig asset()
function that hashes file contents. Apache rewrites the hashed URL to
the canonical file in dynamic mode; build.php writes hashed copies into
dist/ for static mode. Each new commit that changes an asset gets a new
URL, so browsers fetch fresh CSS/JS without manual cache invalidation.